### PR TITLE
feat: Migrate from KIND to Podman Quadlets with database state manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# Virtual environments
+venv/
+ENV/
+env/
+.venv
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Testing
+.pytest_cache/
+.coverage
+htmlcov/
+.tox/
+
+# Logs
+*.log
+
+# OS
+.DS_Store
+Thumbs.db

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,17 +1,23 @@
 # Project Context
 
-This project implements a multi-agent investment committee framework using Langchain, Fedora Bootable Containers, and KIND Kubernetes. It features:
+This project implements a multi-agent investment committee framework using Langchain, Podman Quadlets, and PostgreSQL. It features:
 
-- **MCP Client/Server Integration:**  
+- **MCP Client/Server Integration:**
   Uses the official MCP client to connect to MCP servers defined in a config file. All agents share access to these clients for efficiency.
 
-- **Plugin System:**  
+- **Plugin System:**
   Plugins in `colosseum/plugins/` can register new tools or integrations with the supervisor agent.
 
-- **Agent Architecture:**  
+- **Agent Architecture:**
   The supervisor agent loads MCP servers and plugins, making them available to all agents for secure, efficient access to data and tools.
 
-- **Configuration:**  
+- **State Management:**
+  PostgreSQL (production) or SQLite (development) stores agent state, conversation history, and MCP server cache.
+
+- **Deployment:**
+  Podman Quadlets with systemd provide container orchestration with better localhost networking than Kubernetes.
+
+- **Configuration:**
   Follows XDG and service file system conventions for config and state files.
 
 This context is provided for GitHub Copilot and Amazon Q to assist with code completion and reasoning about the project structure.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 ## Overview
 
-Colosseum is a multi-agent investment committee framework leveraging Langchain, Fedora Bootable Containers, and a KIND single-node Kubernetes cluster. It supports integration with MCP (Model Context Protocol) servers and clients for secure, programmatic access to data, tools, and AI agent management.
+Colosseum is a multi-agent investment committee framework leveraging Langchain, Podman Quadlets, and PostgreSQL for state management. It supports integration with MCP (Model Context Protocol) servers and clients for secure, programmatic access to data, tools, and AI agent management.
+
+Colosseum uses Podman Quadlets for container orchestration via systemd, providing better localhost networking, simpler deployment, and native Fedora integration compared to Kubernetes.
 
 ## MCP Client/Server Integration
 
@@ -30,14 +32,87 @@ Colosseum is a multi-agent investment committee framework leveraging Langchain, 
 
 ## Quickstart
 
+### Installation
+
 1. Install dependencies:
+   ```bash
+   pip install -e .
    ```
-   pip install -r requirements.txt
+
+2. Configure MCP servers:
+   ```bash
+   mkdir -p ~/.config/colosseum
+   cp examples/mcp.json ~/.config/colosseum/mcp.json
+   cp examples/config.yaml ~/.config/colosseum/config.yaml
+   # Edit configuration files with your credentials
    ```
-2. Configure MCP servers in `~/.config/colosseum/mcp.json` or `/etc/colosseum/mcp.json`.
-3. Run the application. Agents will have access to all configured MCP servers and plugins.
+
+3. Deploy with Quadlets (optional, for production):
+   ```bash
+   python -m colosseum.quadlet_deploy deploy
+   ```
+
+### Architecture
+
+```
+┌─────────────────────────────────────────┐
+│  Colosseum Multi-Agent Framework        │
+├─────────────────────────────────────────┤
+│                                         │
+│  ┌──────────────┐  ┌─────────────────┐ │
+│  │  PostgreSQL  │  │  Agent Services │ │
+│  │   Database   │←─┤  - Supervisor   │ │
+│  │  (State)     │  │  - Plugins      │ │
+│  └──────────────┘  │  - MCP Clients  │ │
+│                    └─────────────────┘ │
+│                                         │
+│  Podman Quadlets + systemd              │
+└─────────────────────────────────────────┘
+         ↓
+    localhost:5432 (Database)
+    localhost:8000 (API)
+```
+
+### Development Mode
+
+For development without Quadlets:
+```python
+from colosseum import SupervisorAgent, load_config
+
+# Load configuration
+config = load_config()
+
+# Create supervisor agent
+agent = SupervisorAgent()
+
+# Database will use SQLite by default in ~/.local/share/colosseum/state.db
+```
+
+## Deployment
+
+See [quadlets/README.md](quadlets/README.md) for detailed deployment instructions using Podman Quadlets.
+
+### Why Quadlets instead of KIND?
+
+- **Better localhost access**: No networking issues accessing host services
+- **Simpler setup**: No Kubernetes complexity
+- **Native systemd**: Better integration with Fedora
+- **Easier debugging**: Direct podman commands work
+- **Persistent state**: Built-in volume management
+- **Service discovery**: DNS works out of the box
+
+## Database State Management
+
+Colosseum uses PostgreSQL (production) or SQLite (development) for:
+- Agent state persistence
+- Conversation history
+- MCP server cache
+- Multi-agent coordination
+
+See [colosseum/database.py](colosseum/database.py) for the state management API.
 
 ## References
 
 - [Model Context Protocol (MCP) Client Quickstart](https://modelcontextprotocol.io/quickstart/client)
 - [Langchain Documentation](https://python.langchain.com/)
+- [Podman Quadlet Documentation](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html)

--- a/colosseum/__init__.py
+++ b/colosseum/__init__.py
@@ -1,0 +1,21 @@
+"""
+Colosseum Multi-Agent Investment Committee Framework
+
+A framework for managing multiple AI agents with MCP server integration,
+designed for investment committee workflows with broker and data source connections.
+"""
+
+__version__ = "0.1.0"
+
+from colosseum.agent_supervisor import SupervisorAgent
+from colosseum.agent_registry import AgentRegistry, add_agent_to_registry
+from colosseum.config import get_config_path, load_config, save_config
+
+__all__ = [
+    "SupervisorAgent",
+    "AgentRegistry",
+    "add_agent_to_registry",
+    "get_config_path",
+    "load_config",
+    "save_config",
+]

--- a/colosseum/__init__.py
+++ b/colosseum/__init__.py
@@ -3,6 +3,8 @@ Colosseum Multi-Agent Investment Committee Framework
 
 A framework for managing multiple AI agents with MCP server integration,
 designed for investment committee workflows with broker and data source connections.
+
+Uses Podman Quadlets for deployment and PostgreSQL/SQLite for state management.
 """
 
 __version__ = "0.1.0"
@@ -10,6 +12,13 @@ __version__ = "0.1.0"
 from colosseum.agent_supervisor import SupervisorAgent
 from colosseum.agent_registry import AgentRegistry, add_agent_to_registry
 from colosseum.config import get_config_path, load_config, save_config
+from colosseum.database import (
+    get_db_manager,
+    save_agent_state,
+    load_agent_state,
+    save_conversation,
+    load_conversation_history,
+)
 
 __all__ = [
     "SupervisorAgent",
@@ -18,4 +27,9 @@ __all__ = [
     "get_config_path",
     "load_config",
     "save_config",
+    "get_db_manager",
+    "save_agent_state",
+    "load_agent_state",
+    "save_conversation",
+    "load_conversation_history",
 ]

--- a/colosseum/agent_supervisor.py
+++ b/colosseum/agent_supervisor.py
@@ -1,30 +1,50 @@
-from langchain.agents import AgentExecutor, initialize_agent, Tool
-from langchain.llms import OpenAI
+from langchain_openai import ChatOpenAI
+from langchain_core.tools import Tool
+from langgraph.prebuilt import create_react_agent
 from colosseum.mcp.loader import load_mcp_servers
 
 class SupervisorAgent:
-    def __init__(self, tools=None):
-        self.llm = OpenAI(temperature=0)
+    """
+    Supervisor agent that manages tools and MCP servers for multi-agent workflows.
+
+    Uses LangGraph's create_react_agent for modern agent creation with ReAct prompting.
+    """
+
+    def __init__(self, tools=None, model="gpt-4"):
+        self.llm = ChatOpenAI(temperature=0, model=model)
         self.tools = tools or []
-        self.agent = initialize_agent(
-            self.tools,
-            self.llm,
-            agent="zero-shot-react-description",
-            verbose=True
-        )
+        self._initialize_agent()
         self.mcp_servers = load_mcp_servers()
         # Make MCP servers available for all agents to use directly
         # Agents can access self.mcp_servers as needed
 
+    def _initialize_agent(self):
+        """Initialize or re-initialize the agent with current tools."""
+        if self.tools:
+            # LangGraph's create_react_agent returns a compiled graph that can be invoked
+            self.agent = create_react_agent(self.llm, self.tools)
+        else:
+            self.agent = None
+
     def register_tool(self, tool: Tool):
+        """Register a new tool with the agent and re-initialize."""
         self.tools.append(tool)
         # Re-initialize agent with new tools
-        self.agent = initialize_agent(
-            self.tools,
-            self.llm,
-            agent="zero-shot-react-description",
-            verbose=True
-        )
+        self._initialize_agent()
 
     def run(self, input_text):
-        return self.agent.run(input_text)
+        """
+        Run the agent with the given input.
+
+        Args:
+            input_text: The input query or task for the agent
+
+        Returns:
+            The agent's response
+        """
+        if self.agent is None:
+            raise RuntimeError("No tools registered. Please register at least one tool before running.")
+
+        # LangGraph agents use invoke with messages
+        result = self.agent.invoke({"messages": [("user", input_text)]})
+        return result

--- a/colosseum/agent_supervisor.py
+++ b/colosseum/agent_supervisor.py
@@ -1,22 +1,48 @@
+import uuid
+from typing import Optional, List, Dict, Any
 from langchain_openai import ChatOpenAI
 from langchain_core.tools import Tool
 from langgraph.prebuilt import create_react_agent
 from colosseum.mcp.loader import load_mcp_servers
+from colosseum.database import (
+    save_agent_state,
+    load_agent_state,
+    save_conversation,
+    load_conversation_history,
+)
 
 class SupervisorAgent:
     """
     Supervisor agent that manages tools and MCP servers for multi-agent workflows.
 
     Uses LangGraph's create_react_agent for modern agent creation with ReAct prompting.
+    Integrates with database for state persistence and conversation history.
     """
 
-    def __init__(self, tools=None, model="gpt-4"):
+    def __init__(
+        self,
+        tools=None,
+        model="gpt-4",
+        agent_name: Optional[str] = None,
+        session_id: Optional[str] = None,
+        persist_state: bool = True,
+        persist_conversations: bool = True,
+    ):
+        self.agent_name = agent_name or f"supervisor-{uuid.uuid4().hex[:8]}"
+        self.session_id = session_id or str(uuid.uuid4())
+        self.persist_state = persist_state
+        self.persist_conversations = persist_conversations
+
         self.llm = ChatOpenAI(temperature=0, model=model)
         self.tools = tools or []
         self._initialize_agent()
         self.mcp_servers = load_mcp_servers()
-        # Make MCP servers available for all agents to use directly
-        # Agents can access self.mcp_servers as needed
+
+        # Load previous state if it exists
+        if self.persist_state:
+            previous_state = load_agent_state(self.agent_name, self.session_id)
+            if previous_state:
+                self._restore_state(previous_state)
 
     def _initialize_agent(self):
         """Initialize or re-initialize the agent with current tools."""
@@ -32,7 +58,7 @@ class SupervisorAgent:
         # Re-initialize agent with new tools
         self._initialize_agent()
 
-    def run(self, input_text):
+    def run(self, input_text: str) -> Dict[str, Any]:
         """
         Run the agent with the given input.
 
@@ -45,6 +71,99 @@ class SupervisorAgent:
         if self.agent is None:
             raise RuntimeError("No tools registered. Please register at least one tool before running.")
 
+        # Save user message to conversation history
+        if self.persist_conversations:
+            save_conversation(
+                session_id=self.session_id,
+                agent_name=self.agent_name,
+                role="user",
+                content=input_text,
+            )
+
         # LangGraph agents use invoke with messages
         result = self.agent.invoke({"messages": [("user", input_text)]})
+
+        # Extract assistant response
+        assistant_response = self._extract_response(result)
+
+        # Save assistant message to conversation history
+        if self.persist_conversations:
+            save_conversation(
+                session_id=self.session_id,
+                agent_name=self.agent_name,
+                role="assistant",
+                content=assistant_response,
+                metadata={"full_result": str(result)},
+            )
+
+        # Save current state
+        if self.persist_state:
+            self.save_state()
+
         return result
+
+    def _extract_response(self, result: Dict[str, Any]) -> str:
+        """Extract the text response from LangGraph result."""
+        if "messages" in result:
+            messages = result["messages"]
+            if messages:
+                last_message = messages[-1]
+                if hasattr(last_message, "content"):
+                    return last_message.content
+                elif isinstance(last_message, dict) and "content" in last_message:
+                    return last_message["content"]
+        return str(result)
+
+    def save_state(self, additional_data: Optional[Dict] = None):
+        """
+        Save agent state to database.
+
+        Args:
+            additional_data: Optional additional data to store with state
+        """
+        state_data = {
+            "model": self.llm.model_name if hasattr(self.llm, "model_name") else "gpt-4",
+            "num_tools": len(self.tools),
+            "tool_names": [tool.name for tool in self.tools if hasattr(tool, "name")],
+            "num_mcp_servers": len(self.mcp_servers),
+        }
+
+        if additional_data:
+            state_data.update(additional_data)
+
+        save_agent_state(self.agent_name, self.session_id, state_data)
+
+    def _restore_state(self, state_data: Dict):
+        """
+        Restore agent state from database.
+
+        Args:
+            state_data: State data loaded from database
+        """
+        # For now, just log that we restored state
+        # In future, could restore tool configurations, etc.
+        print(f"Restored state for {self.agent_name}: {state_data}")
+
+    def get_conversation_history(self, limit: Optional[int] = None) -> List[Dict]:
+        """
+        Get conversation history for this agent's session.
+
+        Args:
+            limit: Maximum number of messages to return
+
+        Returns:
+            List of conversation messages
+        """
+        return load_conversation_history(self.session_id, limit=limit)
+
+    def print_conversation_history(self, limit: Optional[int] = 10):
+        """Print formatted conversation history."""
+        history = self.get_conversation_history(limit=limit)
+        print(f"\n=== Conversation History for {self.agent_name} ===")
+        print(f"Session ID: {self.session_id}\n")
+
+        for msg in history:
+            role = msg["role"].upper()
+            content = msg["content"]
+            timestamp = msg["created_at"]
+            print(f"[{timestamp}] {role}: {content}\n")

--- a/colosseum/agent_supervisor.py
+++ b/colosseum/agent_supervisor.py
@@ -69,7 +69,7 @@ class SupervisorAgent:
             The agent's response
         """
         if self.agent is None:
-            raise RuntimeError("No tools registered. Please register at least one tool before running.")
+            raise RuntimeError("No tools registered. Agent requires at least one tool to function. Use register_tool() to add tools before running.")
 
         # Save user message to conversation history
         if self.persist_conversations:

--- a/colosseum/cli.py
+++ b/colosseum/cli.py
@@ -1,0 +1,319 @@
+"""
+Command-line interface for Colosseum multi-agent framework.
+
+Provides commands to:
+- Initialize database
+- Start interactive agent sessions
+- View conversation history
+- Manage agent state
+- Inspect database contents
+"""
+
+import sys
+import argparse
+from typing import Optional
+from colosseum.database import (
+    get_db_manager,
+    AgentState,
+    ConversationHistory,
+    MCPServerState,
+)
+
+
+def init_db(args):
+    """Initialize the database schema."""
+    print("Initializing Colosseum database...")
+    db_manager = get_db_manager()
+    db_manager.init_db()
+    print(f"✓ Database initialized successfully")
+    print(f"  Database URL: {db_manager.database_url}")
+
+
+def list_sessions(args):
+    """List all agent sessions in the database."""
+    db_manager = get_db_manager()
+    session = db_manager.get_session()
+
+    try:
+        # Get all unique sessions
+        sessions = (
+            session.query(AgentState.session_id, AgentState.agent_name)
+            .distinct()
+            .all()
+        )
+
+        if not sessions:
+            print("No sessions found in database.")
+            return
+
+        print(f"\nFound {len(sessions)} session(s):\n")
+        print(f"{'Session ID':<40} {'Agent Name':<20}")
+        print("-" * 60)
+
+        for session_id, agent_name in sessions:
+            print(f"{session_id:<40} {agent_name:<20}")
+
+    finally:
+        session.close()
+
+
+def show_conversation(args):
+    """Show conversation history for a session."""
+    db_manager = get_db_manager()
+    db_session = db_manager.get_session()
+
+    try:
+        query = db_session.query(ConversationHistory).filter_by(
+            session_id=args.session_id
+        )
+
+        if args.agent_name:
+            query = query.filter_by(agent_name=args.agent_name)
+
+        messages = query.order_by(ConversationHistory.created_at).all()
+
+        if not messages:
+            print(f"No conversation found for session: {args.session_id}")
+            return
+
+        print(f"\n=== Conversation History ===")
+        print(f"Session ID: {args.session_id}")
+        if args.agent_name:
+            print(f"Agent: {args.agent_name}")
+        print(f"Messages: {len(messages)}\n")
+
+        for msg in messages:
+            timestamp = msg.created_at.strftime("%Y-%m-%d %H:%M:%S")
+            role = msg.role.upper()
+            agent = msg.agent_name
+            content = msg.content[:200] + "..." if len(msg.content) > 200 else msg.content
+
+            print(f"[{timestamp}] {agent} ({role}):")
+            print(f"  {content}\n")
+
+    finally:
+        db_session.close()
+
+
+def show_state(args):
+    """Show agent state for a session."""
+    db_manager = get_db_manager()
+    db_session = db_manager.get_session()
+
+    try:
+        query = db_session.query(AgentState).filter_by(session_id=args.session_id)
+
+        if args.agent_name:
+            query = query.filter_by(agent_name=args.agent_name)
+
+        states = query.order_by(AgentState.updated_at.desc()).all()
+
+        if not states:
+            print(f"No state found for session: {args.session_id}")
+            return
+
+        print(f"\n=== Agent State ===")
+        print(f"Session ID: {args.session_id}\n")
+
+        for state in states:
+            print(f"Agent: {state.agent_name}")
+            print(f"Updated: {state.updated_at}")
+            print(f"State Data:")
+            for key, value in state.state_data.items():
+                print(f"  {key}: {value}")
+            print()
+
+    finally:
+        db_session.close()
+
+
+def clear_session(args):
+    """Clear all data for a session."""
+    if not args.confirm:
+        print(
+            f"This will delete all data for session: {args.session_id}"
+        )
+        confirm = input("Are you sure? (yes/no): ")
+        if confirm.lower() != "yes":
+            print("Cancelled.")
+            return
+
+    db_manager = get_db_manager()
+    db_session = db_manager.get_session()
+
+    try:
+        # Delete conversation history
+        conv_deleted = (
+            db_session.query(ConversationHistory)
+            .filter_by(session_id=args.session_id)
+            .delete()
+        )
+
+        # Delete agent states
+        state_deleted = (
+            db_session.query(AgentState)
+            .filter_by(session_id=args.session_id)
+            .delete()
+        )
+
+        db_session.commit()
+
+        print(f"✓ Deleted {conv_deleted} conversation messages")
+        print(f"✓ Deleted {state_deleted} agent states")
+
+    finally:
+        db_session.close()
+
+
+def stats(args):
+    """Show database statistics."""
+    db_manager = get_db_manager()
+    db_session = db_manager.get_session()
+
+    try:
+        num_sessions = db_session.query(AgentState.session_id).distinct().count()
+        num_messages = db_session.query(ConversationHistory).count()
+        num_states = db_session.query(AgentState).count()
+        num_mcp = db_session.query(MCPServerState).count()
+
+        print("\n=== Colosseum Database Statistics ===\n")
+        print(f"Database URL: {db_manager.database_url}")
+        print(f"\nCounts:")
+        print(f"  Sessions:      {num_sessions}")
+        print(f"  Messages:      {num_messages}")
+        print(f"  Agent States:  {num_states}")
+        print(f"  MCP Servers:   {num_mcp}")
+
+        # Recent activity
+        recent = (
+            db_session.query(ConversationHistory)
+            .order_by(ConversationHistory.created_at.desc())
+            .limit(5)
+            .all()
+        )
+
+        if recent:
+            print(f"\nRecent Activity:")
+            for msg in recent:
+                timestamp = msg.created_at.strftime("%Y-%m-%d %H:%M:%S")
+                print(f"  [{timestamp}] {msg.agent_name}: {msg.role}")
+
+    finally:
+        db_session.close()
+
+
+def interactive(args):
+    """Start an interactive agent session."""
+    from langchain_core.tools import tool
+    from colosseum import SupervisorAgent
+
+    # Define a simple calculator tool
+    @tool
+    def calculator(expression: str) -> str:
+        """Evaluate a mathematical expression."""
+        try:
+            result = eval(expression, {"__builtins__": {}}, {})
+            return f"Result: {result}"
+        except Exception as e:
+            return f"Error: {str(e)}"
+
+    print("=== Colosseum Interactive Agent ===\n")
+
+    agent = SupervisorAgent(
+        tools=[calculator],
+        agent_name=args.agent_name or "interactive-agent",
+        session_id=args.session_id,
+        model=args.model,
+    )
+
+    print(f"Agent: {agent.agent_name}")
+    print(f"Session: {agent.session_id}")
+    print(f"Model: {args.model}")
+    print("\nType 'exit' to quit, 'history' to view conversation\n")
+
+    while True:
+        try:
+            user_input = input("You: ").strip()
+
+            if not user_input:
+                continue
+
+            if user_input.lower() == "exit":
+                print("Goodbye!")
+                break
+
+            if user_input.lower() == "history":
+                agent.print_conversation_history()
+                continue
+
+            result = agent.run(user_input)
+            print(f"Agent: {result}\n")
+
+        except KeyboardInterrupt:
+            print("\n\nGoodbye!")
+            break
+        except Exception as e:
+            print(f"Error: {e}\n")
+
+
+def main():
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description="Colosseum Multi-Agent Framework CLI"
+    )
+    subparsers = parser.add_subparsers(dest="command", help="Available commands")
+
+    # init-db command
+    parser_init = subparsers.add_parser("init-db", help="Initialize database")
+    parser_init.set_defaults(func=init_db)
+
+    # list-sessions command
+    parser_list = subparsers.add_parser("list-sessions", help="List all sessions")
+    parser_list.set_defaults(func=list_sessions)
+
+    # show-conversation command
+    parser_conv = subparsers.add_parser(
+        "show-conversation", help="Show conversation history"
+    )
+    parser_conv.add_argument("session_id", help="Session ID")
+    parser_conv.add_argument("--agent-name", help="Filter by agent name")
+    parser_conv.set_defaults(func=show_conversation)
+
+    # show-state command
+    parser_state = subparsers.add_parser("show-state", help="Show agent state")
+    parser_state.add_argument("session_id", help="Session ID")
+    parser_state.add_argument("--agent-name", help="Filter by agent name")
+    parser_state.set_defaults(func=show_state)
+
+    # clear-session command
+    parser_clear = subparsers.add_parser("clear-session", help="Clear session data")
+    parser_clear.add_argument("session_id", help="Session ID")
+    parser_clear.add_argument("--confirm", action="store_true", help="Skip confirmation")
+    parser_clear.set_defaults(func=clear_session)
+
+    # stats command
+    parser_stats = subparsers.add_parser("stats", help="Show database statistics")
+    parser_stats.set_defaults(func=stats)
+
+    # interactive command
+    parser_interactive = subparsers.add_parser(
+        "interactive", help="Start interactive session"
+    )
+    parser_interactive.add_argument(
+        "--agent-name", help="Agent name", default="interactive-agent"
+    )
+    parser_interactive.add_argument("--session-id", help="Session ID (auto-generated if not provided)")
+    parser_interactive.add_argument("--model", default="gpt-4", help="Model to use")
+    parser_interactive.set_defaults(func=interactive)
+
+    args = parser.parse_args()
+
+    if not args.command:
+        parser.print_help()
+        return
+
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/colosseum/database.py
+++ b/colosseum/database.py
@@ -123,6 +123,9 @@ def save_agent_state(agent_name: str, session_id: str, state_data: dict):
         )
         session.add(state)
         session.commit()
+    except Exception as e:
+        session.rollback()
+        raise RuntimeError(f"Failed to save agent state: {e}") from e
     finally:
         session.close()
 

--- a/colosseum/database.py
+++ b/colosseum/database.py
@@ -1,0 +1,215 @@
+"""
+Database configuration and state management for Colosseum agents.
+
+Uses SQLAlchemy for ORM and supports PostgreSQL for production,
+SQLite for development/testing.
+"""
+
+import os
+from typing import Optional
+from sqlalchemy import create_engine, Column, Integer, String, JSON, DateTime, Text
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import sessionmaker, Session
+from datetime import datetime
+
+Base = declarative_base()
+
+
+class AgentState(Base):
+    """Store agent state and conversation history."""
+
+    __tablename__ = "agent_states"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    agent_name = Column(String(255), nullable=False, index=True)
+    session_id = Column(String(255), nullable=False, index=True)
+    state_data = Column(JSON, nullable=False, default=dict)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+
+class MCPServerState(Base):
+    """Store MCP server connection state and cache."""
+
+    __tablename__ = "mcp_server_states"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    server_name = Column(String(255), nullable=False, unique=True, index=True)
+    server_type = Column(String(100), nullable=False)
+    state_data = Column(JSON, nullable=False, default=dict)
+    last_connected = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+
+class ConversationHistory(Base):
+    """Store conversation history for multi-agent interactions."""
+
+    __tablename__ = "conversation_history"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    session_id = Column(String(255), nullable=False, index=True)
+    agent_name = Column(String(255), nullable=False)
+    role = Column(String(50), nullable=False)  # user, assistant, system
+    content = Column(Text, nullable=False)
+    metadata = Column(JSON, nullable=True, default=dict)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
+
+
+class DatabaseManager:
+    """Manage database connections and sessions."""
+
+    def __init__(self, database_url: Optional[str] = None):
+        """
+        Initialize database manager.
+
+        Args:
+            database_url: Database connection URL. If None, uses DATABASE_URL env var
+                         or defaults to SQLite in ~/.local/share/colosseum/state.db
+        """
+        if database_url is None:
+            database_url = os.getenv("DATABASE_URL")
+
+        if database_url is None:
+            # Default to SQLite for development
+            state_dir = os.path.expanduser("~/.local/share/colosseum")
+            os.makedirs(state_dir, exist_ok=True)
+            database_url = f"sqlite:///{state_dir}/state.db"
+
+        self.database_url = database_url
+        self.engine = create_engine(database_url, pool_pre_ping=True)
+        self.SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=self.engine)
+
+    def init_db(self):
+        """Initialize database tables."""
+        Base.metadata.create_all(bind=self.engine)
+
+    def get_session(self) -> Session:
+        """Get a new database session."""
+        return self.SessionLocal()
+
+    def close(self):
+        """Close database connections."""
+        self.engine.dispose()
+
+
+# Global database manager instance
+_db_manager: Optional[DatabaseManager] = None
+
+
+def get_db_manager() -> DatabaseManager:
+    """Get or create global database manager."""
+    global _db_manager
+    if _db_manager is None:
+        _db_manager = DatabaseManager()
+        _db_manager.init_db()
+    return _db_manager
+
+
+def save_agent_state(agent_name: str, session_id: str, state_data: dict):
+    """
+    Save agent state to database.
+
+    Args:
+        agent_name: Name of the agent
+        session_id: Session identifier
+        state_data: State data as dictionary
+    """
+    db = get_db_manager()
+    session = db.get_session()
+    try:
+        state = AgentState(
+            agent_name=agent_name, session_id=session_id, state_data=state_data
+        )
+        session.add(state)
+        session.commit()
+    finally:
+        session.close()
+
+
+def load_agent_state(agent_name: str, session_id: str) -> Optional[dict]:
+    """
+    Load agent state from database.
+
+    Args:
+        agent_name: Name of the agent
+        session_id: Session identifier
+
+    Returns:
+        State data dictionary or None if not found
+    """
+    db = get_db_manager()
+    session = db.get_session()
+    try:
+        state = (
+            session.query(AgentState)
+            .filter_by(agent_name=agent_name, session_id=session_id)
+            .order_by(AgentState.created_at.desc())
+            .first()
+        )
+        return state.state_data if state else None
+    finally:
+        session.close()
+
+
+def save_conversation(session_id: str, agent_name: str, role: str, content: str, metadata: Optional[dict] = None):
+    """
+    Save conversation message to database.
+
+    Args:
+        session_id: Session identifier
+        agent_name: Name of the agent
+        role: Message role (user, assistant, system)
+        content: Message content
+        metadata: Optional metadata dictionary
+    """
+    db = get_db_manager()
+    session = db.get_session()
+    try:
+        message = ConversationHistory(
+            session_id=session_id,
+            agent_name=agent_name,
+            role=role,
+            content=content,
+            metadata=metadata or {},
+        )
+        session.add(message)
+        session.commit()
+    finally:
+        session.close()
+
+
+def load_conversation_history(session_id: str, limit: Optional[int] = None) -> list:
+    """
+    Load conversation history from database.
+
+    Args:
+        session_id: Session identifier
+        limit: Maximum number of messages to return (most recent first)
+
+    Returns:
+        List of conversation messages
+    """
+    db = get_db_manager()
+    session = db.get_session()
+    try:
+        query = (
+            session.query(ConversationHistory)
+            .filter_by(session_id=session_id)
+            .order_by(ConversationHistory.created_at.desc())
+        )
+        if limit:
+            query = query.limit(limit)
+        messages = query.all()
+        return [
+            {
+                "agent_name": msg.agent_name,
+                "role": msg.role,
+                "content": msg.content,
+                "metadata": msg.metadata,
+                "created_at": msg.created_at.isoformat(),
+            }
+            for msg in reversed(messages)
+        ]
+    finally:
+        session.close()

--- a/colosseum/database.py
+++ b/colosseum/database.py
@@ -52,7 +52,7 @@ class ConversationHistory(Base):
     agent_name = Column(String(255), nullable=False)
     role = Column(String(50), nullable=False)  # user, assistant, system
     content = Column(Text, nullable=False)
-    metadata = Column(JSON, nullable=True, default=dict)
+    extra_data = Column(JSON, nullable=True, default=dict)  # Renamed from 'metadata' (reserved keyword)
     created_at = Column(DateTime, default=datetime.utcnow, nullable=False, index=True)
 
 
@@ -171,7 +171,7 @@ def save_conversation(session_id: str, agent_name: str, role: str, content: str,
             agent_name=agent_name,
             role=role,
             content=content,
-            metadata=metadata or {},
+            extra_data=metadata or {},  # Using extra_data column
         )
         session.add(message)
         session.commit()
@@ -206,7 +206,7 @@ def load_conversation_history(session_id: str, limit: Optional[int] = None) -> l
                 "agent_name": msg.agent_name,
                 "role": msg.role,
                 "content": msg.content,
-                "metadata": msg.metadata,
+                "metadata": msg.extra_data,  # Return as 'metadata' for backward compatibility
                 "created_at": msg.created_at.isoformat(),
             }
             for msg in reversed(messages)

--- a/colosseum/mcp/__init__.py
+++ b/colosseum/mcp/__init__.py
@@ -1,0 +1,24 @@
+"""
+MCP (Model Context Protocol) integration module
+
+Provides MCP server implementations for various data sources and brokers,
+including base classes and a factory pattern for server instantiation.
+"""
+
+from colosseum.mcp.base import (
+    MCPServer,
+    NewsMCPServer,
+    TickerMCPServer,
+    BrokerMCPServer,
+    mcp_server_factory,
+)
+from colosseum.mcp.loader import load_mcp_servers
+
+__all__ = [
+    "MCPServer",
+    "NewsMCPServer",
+    "TickerMCPServer",
+    "BrokerMCPServer",
+    "mcp_server_factory",
+    "load_mcp_servers",
+]

--- a/colosseum/quadlet_deploy.py
+++ b/colosseum/quadlet_deploy.py
@@ -1,0 +1,255 @@
+"""
+Podman Quadlet deployment and management for Colosseum agents.
+
+Provides functions to deploy, manage, and monitor Colosseum services
+using Podman Quadlets with systemd integration.
+"""
+
+import subprocess
+import shutil
+import os
+from pathlib import Path
+from typing import Optional, List, Dict
+
+
+class QuadletDeployment:
+    """Manage Podman Quadlet deployments for Colosseum."""
+
+    def __init__(self, system_wide: bool = False):
+        """
+        Initialize Quadlet deployment manager.
+
+        Args:
+            system_wide: If True, use system-wide deployment (/etc/containers/systemd)
+                        If False, use user deployment (~/.config/containers/systemd)
+        """
+        self.system_wide = system_wide
+        if system_wide:
+            self.systemd_dir = Path("/etc/containers/systemd")
+            self.systemctl_cmd = ["systemctl"]
+        else:
+            self.systemd_dir = Path.home() / ".config" / "containers" / "systemd"
+            self.systemctl_cmd = ["systemctl", "--user"]
+
+    def install_quadlets(self, source_dir: Optional[Path] = None) -> bool:
+        """
+        Install Quadlet files from source directory to systemd directory.
+
+        Args:
+            source_dir: Directory containing .container, .network, .volume files
+                       Defaults to ./quadlets in the project root
+
+        Returns:
+            True if installation succeeded
+        """
+        if source_dir is None:
+            # Find quadlets directory relative to this file
+            project_root = Path(__file__).parent.parent
+            source_dir = project_root / "quadlets"
+
+        if not source_dir.exists():
+            raise FileNotFoundError(f"Quadlets directory not found: {source_dir}")
+
+        # Create systemd directory if it doesn't exist
+        self.systemd_dir.mkdir(parents=True, exist_ok=True)
+
+        # Copy all quadlet files
+        quadlet_files = list(source_dir.glob("*.network")) + \
+                        list(source_dir.glob("*.volume")) + \
+                        list(source_dir.glob("*.container"))
+
+        if not quadlet_files:
+            raise FileNotFoundError(f"No quadlet files found in {source_dir}")
+
+        for file in quadlet_files:
+            dest = self.systemd_dir / file.name
+            shutil.copy2(file, dest)
+            print(f"Installed: {file.name} -> {dest}")
+
+        # Reload systemd to discover new units
+        self._systemctl(["daemon-reload"])
+        return True
+
+    def enable_services(self, services: Optional[List[str]] = None):
+        """
+        Enable and start Colosseum services.
+
+        Args:
+            services: List of service names to enable. If None, enables all Colosseum services
+        """
+        if services is None:
+            services = [
+                "colosseum-network.service",
+                "colosseum-db-data.service",
+                "colosseum-state.service",
+                "colosseum-db.service",
+                "colosseum-agent.service",
+            ]
+
+        for service in services:
+            print(f"Enabling {service}...")
+            self._systemctl(["enable", "--now", service])
+
+    def disable_services(self, services: Optional[List[str]] = None):
+        """
+        Disable and stop Colosseum services.
+
+        Args:
+            services: List of service names to disable. If None, disables all Colosseum services
+        """
+        if services is None:
+            services = [
+                "colosseum-agent.service",
+                "colosseum-db.service",
+                "colosseum-state.service",
+                "colosseum-db-data.service",
+                "colosseum-network.service",
+            ]
+
+        for service in services:
+            print(f"Disabling {service}...")
+            self._systemctl(["disable", "--now", service])
+
+    def status(self, service: str = "colosseum-agent.service") -> Dict[str, str]:
+        """
+        Get status of a Colosseum service.
+
+        Args:
+            service: Service name to check
+
+        Returns:
+            Dictionary with status information
+        """
+        result = self._systemctl(["status", service], check=False, capture_output=True)
+        return {
+            "service": service,
+            "returncode": result.returncode,
+            "output": result.stdout.decode() if result.stdout else "",
+            "error": result.stderr.decode() if result.stderr else "",
+        }
+
+    def logs(self, service: str = "colosseum-agent.service", follow: bool = False, lines: int = 50):
+        """
+        View logs for a Colosseum service.
+
+        Args:
+            service: Service name
+            follow: If True, follow logs in real-time
+            lines: Number of lines to show
+        """
+        cmd = ["journalctl"]
+        if not self.system_wide:
+            cmd.append("--user")
+        cmd.extend(["-u", service, "-n", str(lines)])
+        if follow:
+            cmd.append("-f")
+
+        subprocess.run(cmd)
+
+    def restart(self, service: str = "colosseum-agent.service"):
+        """
+        Restart a Colosseum service.
+
+        Args:
+            service: Service name to restart
+        """
+        print(f"Restarting {service}...")
+        self._systemctl(["restart", service])
+
+    def exec_in_container(self, container: str, command: List[str]) -> subprocess.CompletedProcess:
+        """
+        Execute a command in a running container.
+
+        Args:
+            container: Container name (e.g., "colosseum-agent")
+            command: Command to execute as list of strings
+
+        Returns:
+            CompletedProcess with command results
+        """
+        cmd = ["podman", "exec", "-it", container] + command
+        return subprocess.run(cmd)
+
+    def db_shell(self):
+        """Open a PostgreSQL shell in the database container."""
+        self.exec_in_container("colosseum-db", ["psql", "-U", "colosseum", "-d", "colosseum"])
+
+    def agent_shell(self):
+        """Open a bash shell in the agent container."""
+        self.exec_in_container("colosseum-agent", ["/bin/bash"])
+
+    def _systemctl(self, args: List[str], check: bool = True, capture_output: bool = False) -> subprocess.CompletedProcess:
+        """
+        Run systemctl command.
+
+        Args:
+            args: Arguments to pass to systemctl
+            check: If True, raise exception on non-zero exit
+            capture_output: If True, capture stdout/stderr
+
+        Returns:
+            CompletedProcess with command results
+        """
+        cmd = self.systemctl_cmd + args
+        return subprocess.run(cmd, check=check, capture_output=capture_output)
+
+
+def deploy_colosseum(system_wide: bool = False):
+    """
+    Deploy Colosseum using Quadlets.
+
+    Args:
+        system_wide: If True, deploy system-wide (requires root)
+                    If False, deploy as user service
+
+    Example:
+        >>> from colosseum.quadlet_deploy import deploy_colosseum
+        >>> deploy_colosseum(system_wide=False)
+    """
+    deployment = QuadletDeployment(system_wide=system_wide)
+
+    print("Installing Quadlet files...")
+    deployment.install_quadlets()
+
+    print("\nEnabling services...")
+    deployment.enable_services()
+
+    print("\nDeployment complete!")
+    print("\nUseful commands:")
+    if system_wide:
+        print("  sudo systemctl status colosseum-agent.service")
+        print("  sudo journalctl -u colosseum-agent.service -f")
+    else:
+        print("  systemctl --user status colosseum-agent.service")
+        print("  journalctl --user -u colosseum-agent.service -f")
+    print("\nAccess database: podman exec -it colosseum-db psql -U colosseum -d colosseum")
+
+
+def undeploy_colosseum(system_wide: bool = False):
+    """
+    Remove Colosseum Quadlet deployment.
+
+    Args:
+        system_wide: If True, remove system-wide deployment
+                    If False, remove user deployment
+    """
+    deployment = QuadletDeployment(system_wide=system_wide)
+
+    print("Disabling services...")
+    deployment.disable_services()
+
+    print("\nTo remove Quadlet files:")
+    print(f"  rm -rf {deployment.systemd_dir}/colosseum-*")
+    print("  Then run: systemctl daemon-reload")
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) > 1 and sys.argv[1] == "deploy":
+        deploy_colosseum(system_wide="--system" in sys.argv)
+    elif len(sys.argv) > 1 and sys.argv[1] == "undeploy":
+        undeploy_colosseum(system_wide="--system" in sys.argv)
+    else:
+        print("Usage: python -m colosseum.quadlet_deploy [deploy|undeploy] [--system]")
+        sys.exit(1)

--- a/colosseum/requirements.txt
+++ b/colosseum/requirements.txt
@@ -1,4 +1,28 @@
+# Core dependencies
+langchain>=0.1.0
+langchain-openai>=0.0.5
+openai>=1.0.0
+
+# MCP (Model Context Protocol)
 mcp
+
+# Web scraping and content processing
 markdownify
 beautifulsoup4
 requests
+
+# Configuration
+PyYAML
+
+# Kubernetes integration
+kubernetes
+
+# Testing
+pytest>=7.0.0
+pytest-cov
+pytest-asyncio
+
+# Development
+black
+flake8
+mypy

--- a/colosseum/requirements.txt
+++ b/colosseum/requirements.txt
@@ -14,8 +14,9 @@ requests
 # Configuration
 PyYAML
 
-# Kubernetes integration
-kubernetes
+# Database
+sqlalchemy>=2.0.0
+psycopg2-binary
 
 # Testing
 pytest>=7.0.0

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,53 @@
+# Configuration Examples
+
+This directory contains example configuration files for the Colosseum framework.
+
+## Files
+
+### mcp.json
+Example MCP (Model Context Protocol) server configuration. This file defines the various MCP servers that agents can connect to for data and tools.
+
+**Location options:**
+- `~/.config/colosseum/mcp.json` (recommended for user-specific config)
+- `/etc/colosseum/mcp.json` (for system-wide config)
+
+**Usage:**
+```bash
+# Copy to your config directory
+mkdir -p ~/.config/colosseum
+cp examples/mcp.json ~/.config/colosseum/mcp.json
+# Edit with your actual credentials
+nano ~/.config/colosseum/mcp.json
+```
+
+### config.yaml
+Main application configuration file for Colosseum settings, agent parameters, and plugin configuration.
+
+**Location options:**
+- `~/.config/colosseum/config.yaml` (XDG standard, user-specific)
+- `/etc/colosseum/config.yaml` (system-wide, requires root)
+- `/var/lib/colosseum/config.yaml` (service-specific)
+
+**Usage:**
+```bash
+# Copy to your config directory
+mkdir -p ~/.config/colosseum
+cp examples/config.yaml ~/.config/colosseum/config.yaml
+# Edit as needed
+nano ~/.config/colosseum/config.yaml
+```
+
+## Environment Variables
+
+You can also configure Colosseum using environment variables:
+
+- `OPENAI_API_KEY` - Your OpenAI API key
+- `MCP_CONFIG_PATH` - Override the default MCP config location
+- `XDG_CONFIG_HOME` - Override the default XDG config directory
+
+## Security Notes
+
+- **Never commit actual credentials** to version control
+- Store sensitive information (API keys, passwords) in environment variables when possible
+- Use file permissions to protect configuration files: `chmod 600 ~/.config/colosseum/*.json`
+- Consider using secret management tools (Vault, AWS Secrets Manager) for production deployments

--- a/examples/agents/README.md
+++ b/examples/agents/README.md
@@ -1,0 +1,184 @@
+# Colosseum Agent Examples
+
+This directory contains example agents demonstrating various features of the Colosseum framework.
+
+## Examples
+
+### 1. Simple Agent (`simple_agent.py`)
+
+Demonstrates basic agent functionality with database persistence:
+- Creating an agent with tools
+- Running queries with conversation history
+- Saving and loading agent state
+- Resuming previous sessions
+
+**Run:**
+```bash
+python examples/agents/simple_agent.py
+```
+
+**Features shown:**
+- Tool registration (calculator, portfolio checker)
+- Automatic conversation persistence
+- State management
+- Session resumption
+
+### 2. Multi-Agent Workflow (`multi_agent.py`)
+
+Shows multiple agents working together through shared database state:
+- Specialized agents (researcher, analyst, decision-maker)
+- Agent coordination via shared state
+- Multi-step workflows
+- Persistent audit trail
+
+**Run:**
+```bash
+python examples/agents/multi_agent.py
+```
+
+**Features shown:**
+- Multiple agent coordination
+- Shared state management
+- Workflow orchestration
+- Complete investment analysis pipeline
+
+## Database Requirements
+
+Before running examples, ensure the database is initialized:
+
+```bash
+# Initialize database (uses SQLite by default in development)
+python -m colosseum.cli init-db
+
+# Or deploy with PostgreSQL using Quadlets
+python -m colosseum.quadlet_deploy deploy
+```
+
+## Viewing Results
+
+After running examples, you can inspect the database:
+
+```bash
+# Show all sessions
+python -m colosseum.cli list-sessions
+
+# Show conversation for a specific session
+python -m colosseum.cli show-conversation demo-session-001
+
+# Show agent state
+python -m colosseum.cli show-state demo-session-001
+
+# Database statistics
+python -m colosseum.cli stats
+```
+
+## Interactive Mode
+
+Start an interactive agent session:
+
+```bash
+# Start interactive session
+python -m colosseum.cli interactive
+
+# With custom agent name and model
+python -m colosseum.cli interactive --agent-name my-agent --model gpt-4
+
+# Resume a previous session
+python -m colosseum.cli interactive --session-id demo-session-001
+```
+
+## Environment Variables
+
+Set your OpenAI API key:
+
+```bash
+export OPENAI_API_KEY="sk-your-key-here"
+```
+
+For PostgreSQL (production):
+
+```bash
+export DATABASE_URL="postgresql://colosseum:password@localhost:5432/colosseum"
+```
+
+## Adding Your Own Tools
+
+Create custom tools for your agents:
+
+```python
+from langchain_core.tools import tool
+from colosseum import SupervisorAgent
+
+@tool
+def my_custom_tool(input: str) -> str:
+    """Description of what the tool does."""
+    # Your tool logic here
+    return f"Processed: {input}"
+
+# Create agent with your tool
+agent = SupervisorAgent(
+    tools=[my_custom_tool],
+    agent_name="my-agent",
+    session_id="my-session"
+)
+
+# Use the agent
+result = agent.run("Please use my custom tool")
+```
+
+## MCP Server Integration
+
+If you have MCP servers configured:
+
+```bash
+# Copy example config
+mkdir -p ~/.config/colosseum
+cp ../mcp.json ~/.config/colosseum/mcp.json
+
+# Edit with your credentials
+nano ~/.config/colosseum/mcp.json
+```
+
+The agent will automatically load and make MCP servers available:
+
+```python
+agent = SupervisorAgent(...)
+# Access MCP servers
+print(f"Available MCP servers: {list(agent.mcp_servers.keys())}")
+```
+
+## Next Steps
+
+- Explore the source code to understand the implementation
+- Modify the examples to test different scenarios
+- Create your own specialized agents
+- Build multi-agent workflows for your use case
+- Integrate with your own data sources via MCP servers
+
+## Troubleshooting
+
+**Database connection errors:**
+```bash
+# Check database status (if using Quadlets)
+systemctl --user status colosseum-db.service
+
+# View database logs
+journalctl --user -u colosseum-db.service -f
+
+# Test database connection
+podman exec -it colosseum-db psql -U colosseum -d colosseum
+```
+
+**Import errors:**
+```bash
+# Ensure package is installed
+pip install -e .
+
+# Check installation
+python -c "import colosseum; print(colosseum.__version__)"
+```
+
+**OpenAI API errors:**
+- Verify your API key is set: `echo $OPENAI_API_KEY`
+- Check your OpenAI account has credits
+- Try with a different model (e.g., `gpt-3.5-turbo`)

--- a/examples/agents/multi_agent.py
+++ b/examples/agents/multi_agent.py
@@ -1,0 +1,164 @@
+"""
+Multi-agent example showing agents communicating through shared database state.
+
+This example demonstrates:
+1. Multiple agents working on the same task
+2. Agents sharing state via database
+3. Agent handoffs and coordination
+4. Persistent multi-agent workflows
+"""
+
+from langchain_core.tools import tool
+from colosseum import SupervisorAgent, save_agent_state, load_agent_state
+
+# Tools for research agent
+@tool
+def research_market(ticker: str) -> str:
+    """Research a stock ticker. Returns mock market data."""
+    mock_data = {
+        "AAPL": "Apple Inc. - Current price: $180.50, P/E: 28.5, Market Cap: $2.8T",
+        "GOOGL": "Alphabet Inc. - Current price: $140.25, P/E: 25.2, Market Cap: $1.7T",
+        "MSFT": "Microsoft Corp. - Current price: $375.80, P/E: 32.1, Market Cap: $2.7T",
+    }
+    return mock_data.get(ticker.upper(), f"No data available for {ticker}")
+
+# Tools for analysis agent
+@tool
+def calculate_metrics(price: float, pe_ratio: float) -> str:
+    """Calculate investment metrics based on price and P/E ratio."""
+    earnings = price / pe_ratio
+    return f"EPS: ${earnings:.2f}, Estimated growth: 12%"
+
+# Tools for decision agent
+@tool
+def make_recommendation(analysis: str) -> str:
+    """Make investment recommendation based on analysis."""
+    return f"Based on analysis: {analysis}\nRecommendation: BUY (Strong confidence)"
+
+
+class MultiAgentWorkflow:
+    """Coordinate multiple agents working together."""
+
+    def __init__(self, session_id: str):
+        self.session_id = session_id
+
+        # Create specialized agents
+        self.research_agent = SupervisorAgent(
+            tools=[research_market],
+            agent_name="researcher",
+            session_id=session_id,
+            model="gpt-4",
+        )
+
+        self.analysis_agent = SupervisorAgent(
+            tools=[calculate_metrics],
+            agent_name="analyst",
+            session_id=session_id,
+            model="gpt-4",
+        )
+
+        self.decision_agent = SupervisorAgent(
+            tools=[make_recommendation],
+            agent_name="decision-maker",
+            session_id=session_id,
+            model="gpt-4",
+        )
+
+    def run_investment_workflow(self, ticker: str):
+        """Run a complete investment analysis workflow."""
+        print(f"\n{'='*60}")
+        print(f"Investment Analysis Workflow for {ticker}")
+        print(f"Session ID: {self.session_id}")
+        print(f"{'='*60}\n")
+
+        # Step 1: Research Agent gathers data
+        print("Step 1: Research Agent gathering market data...")
+        research_query = f"Research the stock ticker {ticker} and provide market data"
+        research_result = self.research_agent.run(research_query)
+        print(f"Research complete: {research_result}\n")
+
+        # Save research results to shared state
+        save_agent_state(
+            "workflow",
+            self.session_id,
+            {"ticker": ticker, "research_data": str(research_result)},
+        )
+
+        # Step 2: Analysis Agent processes the data
+        print("Step 2: Analysis Agent calculating metrics...")
+        # Load research data from shared state
+        shared_state = load_agent_state("workflow", self.session_id)
+        analysis_query = (
+            f"Analyze this stock data and calculate metrics: {shared_state.get('research_data')}"
+        )
+        analysis_result = self.analysis_agent.run(analysis_query)
+        print(f"Analysis complete: {analysis_result}\n")
+
+        # Update shared state with analysis
+        shared_state["analysis_data"] = str(analysis_result)
+        save_agent_state("workflow", self.session_id, shared_state)
+
+        # Step 3: Decision Agent makes recommendation
+        print("Step 3: Decision Agent making recommendation...")
+        shared_state = load_agent_state("workflow", self.session_id)
+        decision_query = (
+            f"Based on this analysis, make an investment recommendation: "
+            f"{shared_state.get('analysis_data')}"
+        )
+        decision_result = self.decision_agent.run(decision_query)
+        print(f"Decision complete: {decision_result}\n")
+
+        # Save final recommendation
+        shared_state["recommendation"] = str(decision_result)
+        save_agent_state("workflow", self.session_id, shared_state)
+
+        print(f"\n{'='*60}")
+        print("Workflow Complete!")
+        print(f"{'='*60}\n")
+
+        return shared_state
+
+    def print_workflow_summary(self):
+        """Print a summary of the entire workflow from database."""
+        print("\n=== Workflow Summary ===\n")
+
+        # Get conversation history from all agents
+        print("Research Agent Activity:")
+        self.research_agent.print_conversation_history(limit=5)
+
+        print("\nAnalysis Agent Activity:")
+        self.analysis_agent.print_conversation_history(limit=5)
+
+        print("\nDecision Agent Activity:")
+        self.decision_agent.print_conversation_history(limit=5)
+
+        # Get shared state
+        shared_state = load_agent_state("workflow", self.session_id)
+        if shared_state:
+            print("\nShared Workflow State:")
+            for key, value in shared_state.items():
+                print(f"  {key}: {value}")
+
+
+def main():
+    print("=== Multi-Agent Investment Committee Example ===\n")
+
+    # Create workflow with shared session
+    workflow = MultiAgentWorkflow(session_id="investment-committee-001")
+
+    # Run analysis for a stock
+    final_state = workflow.run_investment_workflow("AAPL")
+
+    # Print summary showing how agents communicated
+    workflow.print_workflow_summary()
+
+    print("\n=== Key Takeaways ===")
+    print("1. Each agent has its own specialized tools")
+    print("2. Agents communicate via shared database state")
+    print("3. All conversations are persisted for audit trail")
+    print("4. Workflow can be resumed or analyzed later")
+    print(f"5. Session ID '{workflow.session_id}' can be used to access all data\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/agents/simple_agent.py
+++ b/examples/agents/simple_agent.py
@@ -1,0 +1,108 @@
+"""
+Simple example showing agent with database persistence.
+
+This example demonstrates:
+1. Creating an agent with a persistent session
+2. Running multiple queries with conversation history
+3. Saving and loading agent state
+4. Viewing conversation history
+"""
+
+from langchain_core.tools import tool
+from colosseum import SupervisorAgent
+
+# Define a simple tool for the agent
+@tool
+def calculator(expression: str) -> str:
+    """Evaluate a mathematical expression. Input should be a valid Python expression."""
+    try:
+        result = eval(expression, {"__builtins__": {}}, {})
+        return f"Result: {result}"
+    except Exception as e:
+        return f"Error: {str(e)}"
+
+@tool
+def get_portfolio_value() -> str:
+    """Get the current portfolio value. Returns a mock value for demonstration."""
+    return "Portfolio value: $150,000 (mock data)"
+
+
+def main():
+    print("=== Colosseum Agent with Database Persistence Example ===\n")
+
+    # Create an agent with a named session
+    # This allows us to resume the conversation later
+    agent = SupervisorAgent(
+        tools=[calculator, get_portfolio_value],
+        agent_name="investment-advisor",
+        session_id="demo-session-001",
+        model="gpt-4",
+        persist_state=True,
+        persist_conversations=True,
+    )
+
+    print(f"Agent Name: {agent.agent_name}")
+    print(f"Session ID: {agent.session_id}")
+    print(f"Number of tools: {len(agent.tools)}")
+    print(f"Number of MCP servers: {len(agent.mcp_servers)}\n")
+
+    # Example 1: Simple calculation
+    print("--- Query 1: Calculate returns ---")
+    result1 = agent.run("What is 150000 * 0.08?")
+    print(f"Result: {result1}\n")
+
+    # Example 2: Get portfolio value
+    print("--- Query 2: Check portfolio ---")
+    result2 = agent.run("What is my current portfolio value?")
+    print(f"Result: {result2}\n")
+
+    # Example 3: Multi-step reasoning
+    print("--- Query 3: Calculate percentage gain ---")
+    result3 = agent.run(
+        "If my portfolio was worth $140,000 last month and is now $150,000, "
+        "what is the percentage gain?"
+    )
+    print(f"Result: {result3}\n")
+
+    # Save agent state with custom data
+    print("--- Saving agent state ---")
+    agent.save_state({"last_query": "percentage_gain", "user": "demo_user"})
+    print("State saved to database\n")
+
+    # View conversation history
+    print("--- Conversation History ---")
+    agent.print_conversation_history(limit=10)
+
+    print("\n=== Session Complete ===")
+    print(f"Session data saved with ID: {agent.session_id}")
+    print("You can resume this session later by creating a new agent with the same session_id\n")
+
+
+def resume_session():
+    """Example showing how to resume a previous session."""
+    print("\n=== Resuming Previous Session ===\n")
+
+    # Create agent with same session ID
+    agent = SupervisorAgent(
+        tools=[calculator, get_portfolio_value],
+        agent_name="investment-advisor",
+        session_id="demo-session-001",
+        persist_state=True,
+        persist_conversations=True,
+    )
+
+    print("Previous conversation history:")
+    agent.print_conversation_history()
+
+    # Continue the conversation
+    print("\n--- New query in resumed session ---")
+    result = agent.run("What was my last calculation about?")
+    print(f"Result: {result}")
+
+
+if __name__ == "__main__":
+    # Run the main demo
+    main()
+
+    # Optionally uncomment to test session resumption
+    # resume_session()

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,56 @@
+# Colosseum Configuration Example
+# Place this file at one of the following locations:
+# - /etc/colosseum/config.yaml (system-wide, requires root)
+# - /var/lib/colosseum/config.yaml (service-specific)
+# - ~/.config/colosseum/config.yaml (user-specific, XDG standard)
+
+# Application settings
+app:
+  name: "colosseum"
+  log_level: "INFO"
+  debug: false
+
+# MCP configuration
+mcp:
+  # Path to MCP server configuration file
+  config_path: "~/.config/colosseum/mcp.json"
+  # Timeout for MCP server connections (seconds)
+  timeout: 30
+  # Retry attempts for failed connections
+  retry_attempts: 3
+
+# Kubernetes settings
+kubernetes:
+  # Use in-cluster config or local kubeconfig
+  in_cluster: false
+  # Namespace for deployments
+  namespace: "default"
+  # Container image for Fedora bootable containers
+  fedora_image: "fedora:latest"
+
+# Agent settings
+agents:
+  # Default LLM temperature
+  temperature: 0
+  # Verbose logging for agents
+  verbose: true
+  # Agent type (zero-shot-react-description, conversational-react-description, etc.)
+  agent_type: "zero-shot-react-description"
+
+# Plugin settings
+plugins:
+  # Directory containing plugins
+  plugin_dir: "./colosseum/plugins"
+  # Auto-load plugins on startup
+  auto_load: true
+  # List of plugins to load (empty means load all)
+  enabled_plugins: []
+
+# OpenAI settings (if using OpenAI as LLM provider)
+openai:
+  # API key (can also use OPENAI_API_KEY environment variable)
+  # api_key: "sk-..."
+  # Model to use
+  model: "gpt-4"
+  # Max tokens for responses
+  max_tokens: 2000

--- a/examples/mcp.json
+++ b/examples/mcp.json
@@ -2,7 +2,7 @@
   "fetch": {
     "type": "fetch",
     "base_url": "http://localhost:8080",
-    "api_key": "your-api-key-here"
+    "api_key": "${FETCH_API_KEY}"
   },
   "interactive_brokers": {
     "type": "ib",

--- a/examples/mcp.json
+++ b/examples/mcp.json
@@ -1,0 +1,27 @@
+{
+  "fetch": {
+    "type": "fetch",
+    "base_url": "http://localhost:8080",
+    "api_key": "your-api-key-here"
+  },
+  "interactive_brokers": {
+    "type": "ib",
+    "host": "localhost",
+    "port": 7497,
+    "client_id": 1,
+    "account": "your-account-id"
+  },
+  "etrade": {
+    "type": "etrade",
+    "consumer_key": "your-consumer-key",
+    "consumer_secret": "your-consumer-secret",
+    "sandbox": true
+  },
+  "dastrader": {
+    "type": "dastrader",
+    "host": "localhost",
+    "port": 9000,
+    "username": "your-username",
+    "password": "your-password"
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
     "mypy",
 ]
 
+[project.scripts]
+colosseum = "colosseum.cli:main"
+
 [project.urls]
 Homepage = "https://github.com/davdunc/colosseum"
 Repository = "https://github.com/davdunc/colosseum"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = {text = "Apache-2.0"}
 authors = [
     {name = "David Duncan", email = "davdunc@gmail.com"}
 ]
-keywords = ["ai", "agents", "mcp", "investment", "langchain", "kubernetes"]
+keywords = ["ai", "agents", "mcp", "investment", "langchain", "podman", "quadlet"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -34,7 +34,9 @@ dependencies = [
     "beautifulsoup4",
     "requests",
     "PyYAML",
-    "kubernetes",
+    # Database
+    "sqlalchemy>=2.0.0",
+    "psycopg2-binary",  # PostgreSQL adapter
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,93 @@
+[build-system]
+requires = ["setuptools>=65.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "colosseum"
+version = "0.1.0"
+description = "Multi-Agent Investment Committee Framework with MCP integration"
+readme = "README.md"
+requires-python = ">=3.9"
+license = {text = "Apache-2.0"}
+authors = [
+    {name = "David Duncan", email = "davdunc@gmail.com"}
+]
+keywords = ["ai", "agents", "mcp", "investment", "langchain", "kubernetes"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: Apache Software License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+dependencies = [
+    "langchain>=0.1.0",
+    "langchain-openai>=0.0.5",
+    "openai>=1.0.0",
+    "mcp",
+    "markdownify",
+    "beautifulsoup4",
+    "requests",
+    "PyYAML",
+    "kubernetes",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=7.0.0",
+    "pytest-cov",
+    "pytest-asyncio",
+    "black",
+    "flake8",
+    "mypy",
+]
+
+[project.urls]
+Homepage = "https://github.com/davdunc/colosseum"
+Repository = "https://github.com/davdunc/colosseum"
+Issues = "https://github.com/davdunc/colosseum/issues"
+
+[tool.setuptools]
+package-dir = {"" = "."}
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["colosseum*"]
+exclude = ["tests*", "docs*"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests", "colosseum"]
+python_files = ["test_*.py", "*_test.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = "-v --cov=colosseum --cov-report=term-missing"
+
+[tool.black]
+line-length = 100
+target-version = ["py39", "py310", "py311"]
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.venv
+  | build
+  | dist
+)/
+'''
+
+[tool.mypy]
+python_version = "3.9"
+warn_return_any = true
+warn_unused_configs = true
+disallow_untyped_defs = false
+ignore_missing_imports = true
+
+[tool.flake8]
+max-line-length = 100
+extend-ignore = ["E203", "W503"]
+exclude = [".git", "__pycache__", "build", "dist", ".venv"]

--- a/quadlets/README.md
+++ b/quadlets/README.md
@@ -1,0 +1,215 @@
+# Colosseum Quadlet Configuration
+
+This directory contains Podman Quadlet configuration files for running Colosseum with systemd integration.
+
+## What are Quadlets?
+
+Quadlets are systemd unit files that Podman uses to manage containers declaratively. They provide:
+- Native systemd integration
+- Automatic dependency management
+- Better networking than KIND for localhost access
+- Persistent storage with volumes
+- Automatic restarts and health checks
+
+## Architecture
+
+```
+┌─────────────────────────────────────┐
+│  colosseum-network (bridge)         │
+├─────────────────────────────────────┤
+│                                     │
+│  ┌──────────────┐  ┌─────────────┐ │
+│  │ colosseum-db │  │ colosseum-  │ │
+│  │ (PostgreSQL) │←─┤   agent     │ │
+│  └──────────────┘  └─────────────┘ │
+│         ↓                           │
+│    colosseum-db-data (volume)       │
+└─────────────────────────────────────┘
+         ↓
+    Host: localhost:5432 (DB)
+    Host: localhost:8000 (API)
+```
+
+## Installation
+
+### User Service (Recommended for Development)
+
+```bash
+# Create user systemd directory
+mkdir -p ~/.config/containers/systemd/
+
+# Copy quadlet files
+cp quadlets/*.{network,volume,container} ~/.config/containers/systemd/
+
+# Reload systemd to discover quadlets
+systemctl --user daemon-reload
+
+# Enable and start services
+systemctl --user enable --now colosseum-network.service
+systemctl --user enable --now colosseum-db-data.service
+systemctl --user enable --now colosseum-state.service
+systemctl --user enable --now colosseum-db.service
+systemctl --user enable --now colosseum-agent.service
+```
+
+### System Service (Production)
+
+```bash
+# Copy as root
+sudo cp quadlets/*.{network,volume,container} /etc/containers/systemd/
+
+# Reload and start
+sudo systemctl daemon-reload
+sudo systemctl enable --now colosseum-network.service
+sudo systemctl enable --now colosseum-db.service
+sudo systemctl enable --now colosseum-agent.service
+```
+
+## Configuration
+
+### Environment Variables
+
+Create `~/.config/colosseum/env` for secrets:
+
+```bash
+OPENAI_API_KEY=sk-your-key-here
+DATABASE_URL=postgresql://colosseum:your-password@colosseum-db:5432/colosseum
+```
+
+Update `colosseum-agent.container` to load it:
+```ini
+[Service]
+EnvironmentFile=%h/.config/colosseum/env
+```
+
+### Database Password
+
+**IMPORTANT**: Change the default password in `colosseum-db.container`:
+
+```ini
+Environment=POSTGRES_PASSWORD=your-secure-password-here
+```
+
+And update the DATABASE_URL accordingly.
+
+## Management Commands
+
+```bash
+# Check status
+systemctl --user status colosseum-agent.service
+systemctl --user status colosseum-db.service
+
+# View logs
+journalctl --user -u colosseum-agent.service -f
+journalctl --user -u colosseum-db.service -f
+
+# Restart services
+systemctl --user restart colosseum-agent.service
+
+# Stop all services
+systemctl --user stop colosseum-agent.service
+systemctl --user stop colosseum-db.service
+
+# Start all services
+systemctl --user start colosseum-db.service
+systemctl --user start colosseum-agent.service
+```
+
+## Database Access
+
+### From Host
+
+```bash
+# Connect to PostgreSQL from host
+psql -h localhost -p 5432 -U colosseum -d colosseum
+
+# Or using docker exec
+podman exec -it colosseum-db psql -U colosseum -d colosseum
+```
+
+### From Agent Container
+
+The agent container can access the database via the network:
+```python
+# DATABASE_URL is already set in the container
+import os
+db_url = os.getenv("DATABASE_URL")
+# postgresql://colosseum:password@colosseum-db:5432/colosseum
+```
+
+## Building Custom Image
+
+For production, build a custom image with Colosseum installed:
+
+```dockerfile
+# Containerfile
+FROM registry.fedoraproject.org/fedora:latest
+
+RUN dnf install -y python3 python3-pip && dnf clean all
+WORKDIR /opt/colosseum
+COPY . .
+RUN pip install -e .
+
+CMD ["python3", "-m", "colosseum.main"]
+```
+
+Build and update the quadlet:
+```bash
+podman build -t localhost/colosseum:latest .
+
+# Update colosseum-agent.container:
+# Image=localhost/colosseum:latest
+# Exec=python3 -m colosseum.main
+```
+
+## Networking
+
+- **Database**: Accessible at `localhost:5432` from host, `colosseum-db:5432` from containers
+- **Agent API**: Accessible at `localhost:8000` from host
+- **Container to Host**: Use `host.containers.internal` to access host services
+
+This solves the KIND localhost access issue by using Podman's bridge networking with proper DNS.
+
+## Troubleshooting
+
+### Services won't start
+```bash
+# Check systemd status
+systemctl --user status colosseum-*.service
+
+# View detailed logs
+journalctl --user -xe
+```
+
+### Database connection refused
+```bash
+# Check if DB is running
+podman ps | grep colosseum-db
+
+# Check DB logs
+podman logs colosseum-db
+```
+
+### Port already in use
+```bash
+# Check what's using the port
+ss -tlnp | grep 5432
+
+# Change port in quadlet file
+PublishPort=127.0.0.1:5433:5432
+```
+
+## Advantages over KIND
+
+1. **Localhost Access**: No networking issues accessing host services
+2. **Simpler Setup**: No Kubernetes complexity
+3. **Native systemd**: Better integration with Fedora
+4. **Easier Debugging**: Direct podman commands work
+5. **Better Performance**: No Kubernetes overhead
+6. **Persistent State**: Volumes survive container restarts
+7. **Service Discovery**: DNS works out of the box
+
+## References
+
+- [Podman Quadlet Documentation](https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html)
+- [Systemd Service Files](https://www.freedesktop.org/software/systemd/man/systemd.service.html)

--- a/quadlets/colosseum-agent.container
+++ b/quadlets/colosseum-agent.container
@@ -1,0 +1,46 @@
+# Podman Quadlet Container for Colosseum Agent
+# Place this file in ~/.config/containers/systemd/ or /etc/containers/systemd/
+[Unit]
+Description=Colosseum Multi-Agent Framework
+After=colosseum-network.service colosseum-db.container.service colosseum-state.volume.service
+Requires=colosseum-network.service colosseum-state.volume.service
+Wants=colosseum-db.container.service
+
+[Container]
+# Use Fedora as base (or build custom image)
+Image=registry.fedoraproject.org/fedora:latest
+ContainerName=colosseum-agent
+Network=colosseum-network.network
+
+# Mount volumes
+Volume=colosseum-state.volume:/var/lib/colosseum:Z
+Volume=%h/.config/colosseum:/root/.config/colosseum:ro,Z
+
+# Environment variables
+Environment=DATABASE_URL=postgresql://colosseum:colosseum_dev_password@colosseum-db:5432/colosseum
+Environment=PYTHONUNBUFFERED=1
+# Add OpenAI key via systemd override or environment file
+# Environment=OPENAI_API_KEY=sk-...
+
+# Expose API port if needed
+PublishPort=127.0.0.1:8000:8000
+
+# Working directory
+WorkingDir=/opt/colosseum
+
+# Keep container running for development
+# Override with actual command in production
+Exec=/bin/bash -c "sleep infinity"
+
+# Auto-restart
+Restart=on-failure
+RestartSec=10
+
+[Service]
+Type=notify
+NotifyAccess=all
+# Load environment from file (for secrets)
+# EnvironmentFile=%h/.config/colosseum/env
+
+[Install]
+WantedBy=default.target

--- a/quadlets/colosseum-db.container
+++ b/quadlets/colosseum-db.container
@@ -1,0 +1,41 @@
+# Podman Quadlet Container for PostgreSQL Database
+# Place this file in ~/.config/containers/systemd/ or /etc/containers/systemd/
+[Unit]
+Description=Colosseum PostgreSQL Database
+After=colosseum-network.service colosseum-db.volume.service
+Requires=colosseum-network.service colosseum-db.volume.service
+
+[Container]
+Image=docker.io/library/postgres:16-alpine
+ContainerName=colosseum-db
+Network=colosseum-network.network
+
+# Database configuration
+Environment=POSTGRES_DB=colosseum
+Environment=POSTGRES_USER=colosseum
+Environment=POSTGRES_PASSWORD=colosseum_dev_password
+# Change the password above for production!
+
+# Mount volume for persistence
+Volume=colosseum-db-data.volume:/var/lib/postgresql/data:Z
+
+# Expose port for local development access
+PublishPort=127.0.0.1:5432:5432
+
+# Health check
+HealthCmd=pg_isready -U colosseum
+HealthInterval=10s
+HealthTimeout=5s
+HealthRetries=5
+
+# Auto-restart on failure
+Restart=on-failure
+RestartSec=10
+
+[Service]
+# Run as user service (or use system-wide in /etc)
+Type=notify
+NotifyAccess=all
+
+[Install]
+WantedBy=default.target

--- a/quadlets/colosseum-db.volume
+++ b/quadlets/colosseum-db.volume
@@ -1,0 +1,7 @@
+# Podman Quadlet Volume for PostgreSQL persistence
+# Place this file in ~/.config/containers/systemd/ or /etc/containers/systemd/
+[Volume]
+VolumeName=colosseum-db-data
+
+[Install]
+WantedBy=default.target

--- a/quadlets/colosseum-network.network
+++ b/quadlets/colosseum-network.network
@@ -1,0 +1,12 @@
+# Podman Quadlet Network Configuration for Colosseum
+# Place this file in ~/.config/containers/systemd/ or /etc/containers/systemd/
+[Network]
+NetworkName=colosseum
+Driver=bridge
+# Enable DNS for service discovery
+DisableDNS=false
+# Internal network can still access host
+Internal=false
+
+[Install]
+WantedBy=default.target

--- a/quadlets/colosseum-state.volume
+++ b/quadlets/colosseum-state.volume
@@ -1,0 +1,7 @@
+# Podman Quadlet Volume for agent state and configuration
+# Place this file in ~/.config/containers/systemd/ or /etc/containers/systemd/
+[Volume]
+VolumeName=colosseum-state
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
feat(colosseum): migrate orchestration from KIND to Podman Quadlets, implement database-backed state manager 

Replace KIND/Kubernetes deployment with Podman Quadlets and systemd integration for improved local networking, streamlined setup, and native Fedora support.

Introduce PostgreSQL (production) and SQLite (development) state management to persist multi-agent state, MCP server cache, and conversation history.

Refactor agent supervisor and registry to support new deployment and persistence model.

Update configuration examples and documentation to reflect changes in orchestration, state storage, and recommended environment variable usage.

Modernize Python package structure and dependencies.

Minor updates across plugins and MCP modules for compatibility.

Closes #1 
